### PR TITLE
Update pylama for Python 3.10 and increase support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,7 @@ title = "SIGTURK"
   enableInlineShortcodes = false
   [security.exec]
     allow = ["^dart-sass-embedded$", "^go$", "^npx$", "^postcss$", "^asciidoctor$"]
-    osEnv = ["(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM|RUBYLIB)$"]
+    osEnv = ["(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM|RUBYLIB|GEM_PATH)$"]
 
   [security.funcs]
     getenv = ["^HUGO_"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 bandit==1.7.4
 black==22.3.0
-pylama==8.3.8
+pylama==8.4.1


### PR DESCRIPTION
This improves the compatibility with Python 3.10 and latest Ubuntu versions, which are the defaults for GitHub Codespaces