### PR TITLE
Website fixes for 2nd CFP

### DIFF
--- a/content/en/workshop/cfp.txt
+++ b/content/en/workshop/cfp.txt
@@ -20,51 +20,39 @@ TOPICS OF INTEREST
 
 We welcome submissions on, but not limited to, the following topics:
 
--   Computational linguistics: models of all aspects of linguistics in
+*   Computational linguistics: models of all aspects of linguistics in
     Turkic languages (e.g., semantics, syntax, lexicon, morphology)
 
--   Systems: Case studies on the construction of NLP systems for Turkic
+*   Systems: Case studies on the construction of NLP systems for Turkic
     languages
 
--   Evaluation: Understanding the applicability of current NLP methods
+*   Evaluation: Understanding the applicability of current NLP methods
     in Turkic languages
 
--   Metrics: New metrics and measures for evaluating NLP systems
+*   Metrics: New metrics and measures for evaluating NLP systems
     suitable to Turkic languages
 
--   Learning from sparse data: Novel methods for learning from small or
+*   Learning from sparse data: Novel methods for learning from small or
     sparse data in Turkic languages
 
--   Resources: Datasets, benchmarks, and software libraries for NLP
+*   Resources: Datasets, benchmarks, and software libraries for NLP
     models in Turkic languages
 
 IMPORTANT DATES
 
-+-----------------------------------+-----------------------------------+
-| Event                             | Date                              |
-+===================================+===================================+
-| First call for papers             | February 9, 2024 (Friday)         |
-+-----------------------------------+-----------------------------------+
-| Second call for papers            | March 4, 2024 (Monday)            |
-+-----------------------------------+-----------------------------------+
-| Workshop Paper Submission         | May 31, 2024 (Friday)             |
-| Deadline                          |                                   |
-+-----------------------------------+-----------------------------------+
-| Notification of Acceptance        | June 17, 2024 (Monday)            |
-+-----------------------------------+-----------------------------------+
-| Camera-ready Papers Due           | July 1, 2024 (Monday)             |
-+-----------------------------------+-----------------------------------+
-| Workshop Dates                    | August 15-16, 2024                |
-|                                   | (Thursday-Friday)                 |
-+-----------------------------------+-----------------------------------+
+*   First call for papers: February 9, 2024 (Friday)
+*   Paper submission deadline: May 31, 2024 (Friday)
+*   Notification of acceptance: June 16, 2024 (Monday)
+*   Camera-ready submission deadline: July 1, 2024 (Monday)
+*   Workshop dates: August 15-16 (Thursday - Friday)
 
 Note: All deadlines are 11:59 pm UTC -12h (“anywhere on Earth”).
 
 CONTACT INFORMATION
 
--   Email: workshop@sigturk.com
--   Submission Portal: https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK
--   Official Website: https://sigturk.com/workshop
+*   Email: workshop@sigturk.com
+*   Submission Portal: https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK
+*   Official Website: https://sigturk.com/workshop
 
 SUBMISSION GUIDELINES
 
@@ -92,14 +80,25 @@ link: https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK.
 "HACK TOGETHER" PROGRAMMING EVENT
 
 In addition to the workshop itself, the second day will be devoted to a
-full-day collaborative programming event "Hack Together". Our goal is to
+full-day collaborative hybrid programming event "Hack Together". Our goal is to
 demonstrate the SIGTURK NLP library and interested parties can
 contribute to the integration of new NLP methods and models into the
 SIGTURK pipeline. The SIGTURK infrastructure can be found at
 https://github.com/sigturk. Findings of the event will be combined into
 a system demonstration paper.
 
+INVITED SPEAKERS
+Kemal Oflazer, Carnegie Mellon University
+
 MORE INFORMATION
 
 For further details and updates, please visit our workshop website:
 https://sigturk.com/workshop
+
+ORGANIZERS
+Duygu Ataman, New York University
+Deniz Zeyrek Bozşahin, Middle East Technical University
+Mehmet Oguz Derin
+Sardana Ivanova, University of Helsinki
+Abdullatif Köksal, LMU Munich
+Jonne Sälevä, Brandeis University

--- a/content/en/workshop/cfp.txt
+++ b/content/en/workshop/cfp.txt
@@ -1,0 +1,105 @@
+FIRST CALL FOR PAPERS
+---------------------
+
+The First Annual Meeting of the Special Interest Group on Turkic Languages (SIGTURK)
+August 15-16 2024, Bangkok (Co-located with ACL)
+
+INTRODUCTION
+
+We present the first edition of the SIGTURK Workshop representing the
+annual meeting of the ACL Special Interest Group on Turkic Languages,
+which aims to provide a new venue that will promote studies on
+computational linguistics in Turkic languages. Our main objective is to
+bring together an interdisciplinary community of researchers working on
+different aspects of natural language processing (NLP) models and
+corpora in Turkic languages, providing the recently growing number of
+researchers working on the topic with a means of communication and an
+opportunity to present their work and exchange ideas.
+
+TOPICS OF INTEREST
+
+We welcome submissions on, but not limited to, the following topics:
+
+-   Computational linguistics: models of all aspects of linguistics in
+    Turkic languages (e.g., semantics, syntax, lexicon, morphology)
+
+-   Systems: Case studies on the construction of NLP systems for Turkic
+    languages
+
+-   Evaluation: Understanding the applicability of current NLP methods
+    in Turkic languages
+
+-   Metrics: New metrics and measures for evaluating NLP systems
+    suitable to Turkic languages
+
+-   Learning from sparse data: Novel methods for learning from small or
+    sparse data in Turkic languages
+
+-   Resources: Datasets, benchmarks, and software libraries for NLP
+    models in Turkic languages
+
+IMPORTANT DATES
+
++-----------------------------------+-----------------------------------+
+| Event                             | Date                              |
++===================================+===================================+
+| First call for papers             | February 9, 2024 (Friday)         |
++-----------------------------------+-----------------------------------+
+| Second call for papers            | March 4, 2024 (Monday)            |
++-----------------------------------+-----------------------------------+
+| Workshop Paper Submission         | May 31, 2024 (Friday)             |
+| Deadline                          |                                   |
++-----------------------------------+-----------------------------------+
+| Notification of Acceptance        | June 17, 2024 (Monday)            |
++-----------------------------------+-----------------------------------+
+| Camera-ready Papers Due           | July 1, 2024 (Monday)             |
++-----------------------------------+-----------------------------------+
+| Workshop Dates                    | August 15-16, 2024                |
+|                                   | (Thursday-Friday)                 |
++-----------------------------------+-----------------------------------+
+
+Note: All deadlines are 11:59 pm UTC -12h (“anywhere on Earth”).
+
+CONTACT INFORMATION
+
+-   Email: workshop@sigturk.com
+-   Submission Portal: https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK
+-   Official Website: https://sigturk.com/workshop
+
+SUBMISSION GUIDELINES
+
+Research papers
+
+We invite all potential participants to submit their novel research
+contributions in the related fields as long papers following the ACL
+2024 long paper format (anonymized with 8 pages excluding the
+references, and an additional page for the camera-ready versions for the
+accepted papers). All accepted research papers will be published as part
+of our workshop proceedings and will be presented either through oral
+presentations or poster sessions. Our research paper track will accept
+submissions through our own submission system available at
+https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK.
+
+Extended abstracts
+
+Besides long paper submissions, we also invite previously published or
+ongoing and incomplete research contributions to our non-archival
+extended abstract track. All extended abstracts can use the same EMNLP
+template with a 2-page limit, excluding the bibliography. Extended
+abstracts can be submitted to the workshop submission system using the
+link: https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK.
+
+"HACK TOGETHER" PROGRAMMING EVENT
+
+In addition to the workshop itself, the second day will be devoted to a
+full-day collaborative programming event "Hack Together". Our goal is to
+demonstrate the SIGTURK NLP library and interested parties can
+contribute to the integration of new NLP methods and models into the
+SIGTURK pipeline. The SIGTURK infrastructure can be found at
+https://github.com/sigturk. Findings of the event will be combined into
+a system demonstration paper.
+
+MORE INFORMATION
+
+For further details and updates, please visit our workshop website:
+https://sigturk.com/workshop

--- a/content/en/workshop/index.adoc
+++ b/content/en/workshop/index.adoc
@@ -130,7 +130,7 @@ We are committed to promoting diversity and inclusion within our community.
 
 == Workshop format
 
-The workshop will be conducted in a hybrid format, offering both in-person and virtual participation options.
+The workshop will be conducted in a hybrid format, with both an in-person component and virtual participation options.
 
 == Venue
 

--- a/content/en/workshop/index.adoc
+++ b/content/en/workshop/index.adoc
@@ -122,7 +122,7 @@ Besides long paper submissions, we also invite previously published or ongoing a
 
 == Awards
 
-A best paper award and winners of the shared task will be presented at the workshop and will be announced on our website.
+A best paper award will be presented at the workshop and will be announced on our website.
 
 == Diversity and inclusion statement
 

--- a/content/en/workshop/index.adoc
+++ b/content/en/workshop/index.adoc
@@ -126,7 +126,7 @@ A best paper award and winners of the shared task will be presented at the works
 
 == Diversity and inclusion statement
 
-We are committed to promoting diversity and inclusion within our community. Part of our sponsorship funds are allocated to support participation from under-represented groups.
+We are committed to promoting diversity and inclusion within our community.
 
 == Workshop format
 

--- a/content/en/workshop/index.adoc
+++ b/content/en/workshop/index.adoc
@@ -38,7 +38,7 @@ are applicable to a wide range of Turkic languages.
 [options="header"]
 |===
 | Event | Date
-| First call for papers | February 7, 2024 (Wednesday)
+| First call for papers | February 9, 2024 (Friday)
 | Second call for papers | March 4, 2024 (Monday)
 | Workshop Paper Submission Deadline | May 31, 2024 (Friday)
 | Notification of Acceptance | June 17, 2024 (Monday)


### PR DESCRIPTION
This PR implements changes to the SIGTURK workshop website that clarify organizational details.

The following changes were made

- Removed note about sponsorship funds
- Removed note about shared task
- Clarified hybrid nature of the event