### PR TITLE
Reorder the contents of the workshop page

### DIFF
--- a/content/en/workshop/index.adoc
+++ b/content/en/workshop/index.adoc
@@ -11,7 +11,7 @@ contributors: []
 
 = The First Annual Meeting of the Special Interest Group on Turkic Languages (SIGTURK) August 15-16 2024, Bangkok (Co-located with ACL)
 
-= Introduction
+== Introduction
 
 We are excited to announce the First Annual Meeting of the ACL Special Interest
 Group on Turkic Languages, held  in conjunction with https://2024.aclweb.org/[Annual Meeting of the
@@ -49,26 +49,60 @@ are applicable to a wide range of Turkic languages.
 | Workshop Dates | August 15-16, 2024 (Thursday-Friday)
 |===
 
+== Topics of interest
+
+We welcome submissions on, but not limited to, the following topics:
+
+* Computational linguistics: models of all aspects of linguistics in Turkic languages (e.g., semantics, syntax, lexicon, morphology)
+* Systems: Case studies on the construction of NLP systems for Turkic languages
+* Evaluation: Understanding the applicability of current NLP methods in Turkic languages
+* Metrics: New metrics and measures for evaluating NLP systems suitable to Turkic languages
+* Learning from sparse data: Novel methods for learning from small or sparse data in Turkic languages
+* Resources: Datasets, benchmarks, and software libraries for NLP models in Turkic languages
+
 Note: All deadlines are 11:59 pm UTC -12h (“anywhere on Earth”).
 
-== Contact information
+== "Hack Together" programming event
 
-* Email: workshop@sigturk.com
-* Submission Portal: https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK
-* Official Website: https://sigturk.com/workshop
+In addition to the workshop itself, the second day will be devoted to a full-day collaborative programming event "Hack Together".
+Our goal is to demonstrate the SIGTURK NLP library and interested parties can contribute to the integration of new NLP methods and models into the SIGTURK pipeline.
+The SIGTURK infrastructure can be found at https://github.com/sigturk.
+Findings of the event will be combined into a system demonstration paper.
 
-== Organizing committee
+== Submission guidelines
 
-* Duygu Ataman, New York University
-* Deniz Zeyrek Bozşahin, Middle East Technical University
-* Mehmet Oguz Derin
-* Sardana Ivanova, University of Helsinki
-* Abdullatif Köksal, LMU Munich
-* Jonne Sälevä, Brandeis University
+=== Research papers
+
+We invite all potential participants to submit their novel research contributions in the related fields as long papers following the ACL 2024 long paper format (anonymized with 8 pages excluding the references, and an additional page for the camera-ready versions for the accepted papers). All accepted research papers will be published as part of our workshop proceedings and will be presented either through oral presentations or poster sessions.
+Our research paper track will accept submissions through our own submission system available at https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK.
+
+=== Extended abstracts
+
+Besides long paper submissions, we also invite previously published or ongoing and incomplete research contributions to our non-archival extended abstract track. All extended abstracts can use the same EMNLP template with a 2-page limit, excluding the bibliography. Extended abstracts can be submitted to the workshop submission system using the link: https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK.
 
 == Invited speakers
 
 * Kemal Oflazer, CMU
+
+== Awards
+
+A best paper award will be presented at the workshop and will be announced on our website.
+
+== Diversity and inclusion statement
+
+We are committed to promoting diversity and inclusion within our community.
+
+== Workshop format
+
+The workshop will be conducted in a hybrid format, with both an in-person component and virtual participation options.
+
+== Registration
+
+Details regarding registration will be available on our website closer to the event.
+
+== Venue
+
+The workshop will be held in Bangkok, Thailand. Future details TBA.
 
 == Program committee
 
@@ -94,54 +128,20 @@ Note: All deadlines are 11:59 pm UTC -12h (“anywhere on Earth”).
 * Francis Tyers, Indiana University
 * Jonathan Washington, Swarthmore College
 
-== Topics of interest
+== Organizing committee
 
-We welcome submissions on, but not limited to, the following topics:
+* Duygu Ataman, New York University
+* Deniz Zeyrek Bozşahin, Middle East Technical University
+* Mehmet Oguz Derin
+* Sardana Ivanova, University of Helsinki
+* Abdullatif Köksal, LMU Munich
+* Jonne Sälevä, Brandeis University
 
-* Computational linguistics: models of all aspects of linguistics in Turkic languages (e.g., semantics, syntax, lexicon, morphology)
-* Systems: Case studies on the construction of NLP systems for Turkic languages
-* Evaluation: Understanding the applicability of current NLP methods in Turkic languages
-* Metrics: New metrics and measures for evaluating NLP systems suitable to Turkic languages
-* Learning from sparse data: Novel methods for learning from small or sparse data in Turkic languages
-* Resources: Datasets, benchmarks, and software libraries for NLP models in Turkic languages
+== Contact information
 
-== "Hack Together" programming event
-
-In addition to the workshop itself, the second day will be devoted to a full-day collaborative programming event "Hack Together".
-Our goal is to demonstrate the SIGTURK NLP library and interested parties can contribute to the integration of new NLP methods and models into the SIGTURK pipeline.
-The SIGTURK infrastructure can be found at https://github.com/sigturk.
-Findings of the event will be combined into a system demonstration paper.
-
-== Submission guidelines
-
-=== Research papers
-
-We invite all potential participants to submit their novel research contributions in the related fields as long papers following the ACL 2024 long paper format (anonymized with 8 pages excluding the references, and an additional page for the camera-ready versions for the accepted papers). All accepted research papers will be published as part of our workshop proceedings and will be presented either through oral presentations or poster sessions.
-Our research paper track will accept submissions through our own submission system available at https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK.
-
-=== Extended abstracts
-
-Besides long paper submissions, we also invite previously published or ongoing and incomplete research contributions to our non-archival extended abstract track. All extended abstracts can use the same EMNLP template with a 2-page limit, excluding the bibliography. Extended abstracts can be submitted to the workshop submission system using the link: https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK.
-
-== Awards
-
-A best paper award will be presented at the workshop and will be announced on our website.
-
-== Diversity and inclusion statement
-
-We are committed to promoting diversity and inclusion within our community.
-
-== Workshop format
-
-The workshop will be conducted in a hybrid format, with both an in-person component and virtual participation options.
-
-== Venue
-
-The workshop will be held in Bangkok, Thailand. Future details TBA.
-
-== Registration
-
-Details regarding registration will be available on our website closer to the event.
+* Email: workshop@sigturk.com
+* Submission Portal: https://openreview.net/group?id=aclweb.org/ACL/2024/Workshop/SIGTURK
+* Official Website: https://sigturk.com/workshop
 
 == More information
 


### PR DESCRIPTION
I've just reordered the workshop page contents according to https://github.com/sigturk/sigturk/issues/125. No changes have been made to the content itself.



