### PR TITLE
Add workshop program

### DIFF
--- a/content/en/workshop2026-program/index.adoc
+++ b/content/en/workshop2026-program/index.adoc
@@ -1,0 +1,81 @@
+---
+title: "SIGTURK 2026 Workshop - Program"
+description: "Schedule for The Second Workshop on Natural Language Processing for Turkic Languages (SIGTURK 2026)"
+draft: false
+toc: true
+images: []
+aliases: ["/workshop/program/"]
+contributors: []
+---
+
+== Sunday, March 29, 2026
+
+=== 09:00 - 09:15 Opening Remarks
+
+=== 09:15 - 10:30 Session 1
+
+SindBERT, the Sailor: Charting the Seas of Turkish NLP +
+*Raphael Schmitt, Stefan Schweter*
+
+Building a Turkish Large Language Model via Continual Pre-Training and Parameter-Efficient Adaptation +
+*Alperen Enes Bayar, Mert Ege, Gökhan Yurtalan, Alper Karamanlioglu, Berkan Demirel, Ramazan Gokberk Cinbis*
+
+When Semantic Overlap Is Not Enough: Cross-Lingual Euphemism Transfer Between Turkish and English +
+*Hasan Can Biyik, Libby Barak, Jing Peng, Anna Feldman*
+
+BIRDTurk: Adaptation of the BIRD Text-to-SQL Dataset to Turkish +
+*Burak Aktaş, Mehmet Can Baytekin, Süha Kağan Köse, Ömer İlbilgi, Elif Özge Yılmaz, Cagri Toraman, Bilge Kaan Görür*
+
+Overview of the SIGTURK 2026 Shared Task: Terminology-Aware Machine Translation for English–Turkish Scientific Texts +
+*Ali Gebeşçe, Abdulfattah Safa, Ege Uğur Amasya, Gözde Gül Şahin*
+
+=== 10:30 - 11:00 Coffee Break
+
+=== 11:00 - 12:00 Session 2
+
+TUNE: A Task For Turkish Machine Unlearning For Data Privacy +
+*Doruk Benli, Ada Canoğlu, Nehir İlkim Gönençer, Dilara Keküllüoğlu*
+
+TurkBench: A Benchmark for Evaluating Turkish Large Language Models +
+*Cagri Toraman, Ahmet Kaan Sever, Ayşe Aysu Cengiz, Elif Ecem Arslan, Görkem Sevinç, Sarp Kantar, Mete Mert Birdal, Yusuf Faruk Güldemir, Ali Buğra Kanburoğlu, Sezen Felekoğlu, Birsen Şahin Kütük, Büşra Tufan, Elif Genç, Serkan Coşkun, Gupse Ekin Demir, Muhammed Emin Arayıcı, Olgun Dursun, Onur Gungor, Susan Üsküdarlı, Abdullah Topraksoy, Esra Darıcı*
+
+Modelling the Morphology of Verbal Paradigms: A Case Study in the Tokenization of Turkish and Hebrew +
+*Giuseppe Samo, Paola Merlo*
+
+Beyond the Token: Correcting the Tokenization Bias in XAI via Morphologically-Aligned Projection +
+*Muhammet Anil Yagiz, Fahrettin Horasan*
+
+=== 14:00 - 17:00 Poster Session
+
+TR-EduVSum: A Turkish-Focused Dataset and Consensus Framework for Educational Video Summarization +
+*Figen Eğin, Aytuğ Onan*
+
+SarcasTürk: Turkish Context-Aware Sarcasm Detection Dataset +
+*Niyazi Ahmet Metin, Sevde Yılmaz, Osman Enes Erdoğdu, Elif Sude Meydan, Oğul Sümer, Dilara Keküllüoğlu*
+
+RAGTurk: Best Practices for Retrieval Augmented Generation in Turkish +
+*Süha Kağan Köse, Can Baytekin, Burak Aktaş, Kaan Görür, Evren Ayberk Munis, Deniz Yılmaz, Muhammed Yusuf Kartal, Cagri Toraman*
+
+A Morphology-Aware Evaluation of Turkish Syntax in Large Language Models +
+*Ezgi Başar, Arianna Bisazza*
+
+OCRTurk: A Comprehensive OCR Benchmark for Turkish +
+*Deniz Yılmaz, Evren Ayberk Munis, Cagri Toraman, Süha Kağan Köse, Burak Aktaş, Mehmet Can Baytekin, Bilge Kaan Görür*
+
+A Unified Turkic Idiom Understanding Benchmark: Idiom Detection and Semantic Retrieval Across Five Turkic Languages +
+*Gözde Aslantaş, Tunga Gungor*
+
+Language Matters: Target-Language Supervision for Political Bias Detection in Turkish News +
+*Umut Ozbagriacik, Haim Dubossarsky*
+
+Benchmarking Hate Speech Detection in Azerbaijani with Turkish Cross-Lingual Transfer and Transformer Models +
+*Tural Alizada, Haim Dubossarsky*
+
+From Lemmas to Dependencies: What Signals Drive Light Verbs Classification? +
+*Sercan Karakas, Yusuf Şimşek*
+
+Directed Attention is All You Need: Profiling Style from Limited Text Data +
+*Hüseyin Emir Akdağ*
+
+Tokenisation of Turkic Copula Constructions in Universal Dependencies +
+*Cagri Coltekin, Furkan Akkurt, Bermet Chontaeva, Soudabeh Eslami, Sardana Ivanova, Gulnura Dzhumalieva, Aida Kasieva, Nikolett Mus, Jonathan Washington*

--- a/content/en/workshop2026-program/index.adoc
+++ b/content/en/workshop2026-program/index.adoc
@@ -8,6 +8,46 @@ aliases: ["/workshop/program/"]
 contributors: []
 ---
 
+[cols="1,4"]
+|===
+| Time | Session
+
+| 09:00 - 09:15
+| **Opening Remarks**
+
+| 09:15 - 10:30
+| **Session 1**
+* _SindBERT, the Sailor: Charting the Seas of Turkish NLP_
+* _Building a Turkish Large Language Model via Continual Pre-Training and Parameter-Efficient Adaptation_
+* _When Semantic Overlap Is Not Enough: Cross-Lingual Euphemism Transfer Between Turkish and English_
+* _BIRDTurk: Adaptation of the BIRD Text-to-SQL Dataset to Turkish_
+* _Overview of the SIGTURK 2026 Shared Task: Terminology-Aware Machine Translation for English–Turkish Scientific Texts_
+
+| 10:30 - 11:00
+| **Coffee Break**
+
+| 11:00 - 12:00
+| **Session 2**
+* _TUNE: A Task For Turkish Machine Unlearning For Data Privacy_
+* _TurkBench: A Benchmark for Evaluating Turkish Large Language Models_
+* _Modelling the Morphology of Verbal Paradigms: A Case Study in the Tokenization of Turkish and Hebrew_
+* _Beyond the Token: Correcting the Tokenization Bias in XAI via Morphologically-Aligned Projection_
+
+| 14:00 - 17:00
+| **Poster Session**
+* _TR-EduVSum: A Turkish-Focused Dataset and Consensus Framework for Educational Video Summarization_
+* _SarcasTürk: Turkish Context-Aware Sarcasm Detection Dataset_
+* _RAGTurk: Best Practices for Retrieval Augmented Generation in Turkish_
+* _A Morphology-Aware Evaluation of Turkish Syntax in Large Language Models_
+* _OCRTurk: A Comprehensive OCR Benchmark for Turkish_
+* _A Unified Turkic Idiom Understanding Benchmark: Idiom Detection and Semantic Retrieval Across Five Turkic Languages_
+* _Language Matters: Target-Language Supervision for Political Bias Detection in Turkish News_
+* _Benchmarking Hate Speech Detection in Azerbaijani with Turkish Cross-Lingual Transfer and Transformer Models_
+* _From Lemmas to Dependencies: What Signals Drive Light Verbs Classification?_
+* _Directed Attention is All You Need: Profiling Style from Limited Text Data_
+* _Tokenisation of Turkic Copula Constructions in Universal Dependencies_
+|===
+
 === Sunday, March 29, 2026
 
 ==== 09:00 - 09:15 Opening Remarks

--- a/content/en/workshop2026-program/index.adoc
+++ b/content/en/workshop2026-program/index.adoc
@@ -16,36 +16,76 @@ contributors: []
 | **Opening Remarks**
 
 | 09:15 - 10:30
-| **Session 1**
-* _SindBERT, the Sailor: Charting the Seas of Turkish NLP_
-* _Building a Turkish Large Language Model via Continual Pre-Training and Parameter-Efficient Adaptation_
-* _When Semantic Overlap Is Not Enough: Cross-Lingual Euphemism Transfer Between Turkish and English_
-* _BIRDTurk: Adaptation of the BIRD Text-to-SQL Dataset to Turkish_
-* _Overview of the SIGTURK 2026 Shared Task: Terminology-Aware Machine Translation for English–Turkish Scientific Texts_
+a| **Session 1**
+
+* *SindBERT, the Sailor: Charting the Seas of Turkish NLP* +
+_Raphael Schmitt, Stefan Schweter_
+
+* *Building a Turkish Large Language Model via Continual Pre-Training and Parameter-Efficient Adaptation* +
+_Alperen Enes Bayar, Mert Ege, Gökhan Yurtalan, Alper Karamanlioglu, Berkan Demirel, Ramazan Gokberk Cinbis_
+
+* *When Semantic Overlap Is Not Enough: Cross-Lingual Euphemism Transfer Between Turkish and English* +
+_Hasan Can Biyik, Libby Barak, Jing Peng, Anna Feldman_
+
+* *BIRDTurk: Adaptation of the BIRD Text-to-SQL Dataset to Turkish* +
+_Burak Aktaş, Mehmet Can Baytekin, Süha Kağan Köse, Ömer İlbilgi, Elif Özge Yılmaz, Cagri Toraman, Bilge Kaan Görür_
+
+* *Overview of the SIGTURK 2026 Shared Task: Terminology-Aware Machine Translation for English–Turkish Scientific Texts* +
+_Ali Gebeşçe, Abdulfattah Safa, Ege Uğur Amasya, Gözde Gül Şahin_
 
 | 10:30 - 11:00
 | **Coffee Break**
 
 | 11:00 - 12:00
-| **Session 2**
-* _TUNE: A Task For Turkish Machine Unlearning For Data Privacy_
-* _TurkBench: A Benchmark for Evaluating Turkish Large Language Models_
-* _Modelling the Morphology of Verbal Paradigms: A Case Study in the Tokenization of Turkish and Hebrew_
-* _Beyond the Token: Correcting the Tokenization Bias in XAI via Morphologically-Aligned Projection_
+a| **Session 2**
+
+* *TUNE: A Task For Turkish Machine Unlearning For Data Privacy* +
+_Doruk Benli, Ada Canoğlu, Nehir İlkim Gönençer, Dilara Keküllüoğlu_
+
+* *TurkBench: A Benchmark for Evaluating Turkish Large Language Models* +
+_Cagri Toraman, Ahmet Kaan Sever, Ayşe Aysu Cengiz, Elif Ecem Arslan, Görkem Sevinç, Sarp Kantar, Mete Mert Birdal, Yusuf Faruk Güldemir, Ali Buğra Kanburoğlu, Sezen Felekoğlu, Birsen Şahin Kütük, Büşra Tufan, Elif Genç, Serkan Coşkun, Gupse Ekin Demir, Muhammed Emin Arayıcı, Olgun Dursun, Onur Gungor, Susan Üsküdarlı, Abdullah Topraksoy, Esra Darıcı_
+
+* *Modelling the Morphology of Verbal Paradigms: A Case Study in the Tokenization of Turkish and Hebrew* +
+_Giuseppe Samo, Paola Merlo_
+
+* *Beyond the Token: Correcting the Tokenization Bias in XAI via Morphologically-Aligned Projection* +
+_Muhammet Anil Yagiz, Fahrettin Horasan_
 
 | 14:00 - 17:00
-| **Poster Session**
-* _TR-EduVSum: A Turkish-Focused Dataset and Consensus Framework for Educational Video Summarization_
-* _SarcasTürk: Turkish Context-Aware Sarcasm Detection Dataset_
-* _RAGTurk: Best Practices for Retrieval Augmented Generation in Turkish_
-* _A Morphology-Aware Evaluation of Turkish Syntax in Large Language Models_
-* _OCRTurk: A Comprehensive OCR Benchmark for Turkish_
-* _A Unified Turkic Idiom Understanding Benchmark: Idiom Detection and Semantic Retrieval Across Five Turkic Languages_
-* _Language Matters: Target-Language Supervision for Political Bias Detection in Turkish News_
-* _Benchmarking Hate Speech Detection in Azerbaijani with Turkish Cross-Lingual Transfer and Transformer Models_
-* _From Lemmas to Dependencies: What Signals Drive Light Verbs Classification?_
-* _Directed Attention is All You Need: Profiling Style from Limited Text Data_
-* _Tokenisation of Turkic Copula Constructions in Universal Dependencies_
+a| **Poster Session**
+
+* *TR-EduVSum: A Turkish-Focused Dataset and Consensus Framework for Educational Video Summarization* +
+_Figen Eğin, Aytuğ Onan_
+
+* *SarcasTürk: Turkish Context-Aware Sarcasm Detection Dataset* +
+_Niyazi Ahmet Metin, Sevde Yılmaz, Osman Enes Erdoğdu, Elif Sude Meydan, Oğul Sümer, Dilara Keküllüoğlu_
+
+* *RAGTurk: Best Practices for Retrieval Augmented Generation in Turkish* +
+_Süha Kağan Köse, Can Baytekin, Burak Aktaş, Kaan Görür, Evren Ayberk Munis, Deniz Yılmaz, Muhammed Yusuf Kartal, Cagri Toraman_
+
+* *A Morphology-Aware Evaluation of Turkish Syntax in Large Language Models* +
+_Ezgi Başar, Arianna Bisazza_
+
+* *OCRTurk: A Comprehensive OCR Benchmark for Turkish* +
+_Deniz Yılmaz, Evren Ayberk Munis, Cagri Toraman, Süha Kağan Köse, Burak Aktaş, Mehmet Can Baytekin, Bilge Kaan Görür_
+
+* *A Unified Turkic Idiom Understanding Benchmark: Idiom Detection and Semantic Retrieval Across Five Turkic Languages* +
+_Gözde Aslantaş, Tunga Gungor_
+
+* *Language Matters: Target-Language Supervision for Political Bias Detection in Turkish News* +
+_Umut Ozbagriacik, Haim Dubossarsky_
+
+* *Benchmarking Hate Speech Detection in Azerbaijani with Turkish Cross-Lingual Transfer and Transformer Models* +
+_Tural Alizada, Haim Dubossarsky_
+
+* *From Lemmas to Dependencies: What Signals Drive Light Verbs Classification?* +
+_Sercan Karakas, Yusuf Şimşek_
+
+* *Directed Attention is All You Need: Profiling Style from Limited Text Data* +
+_Hüseyin Emir Akdağ_
+
+* *Tokenisation of Turkic Copula Constructions in Universal Dependencies* +
+_Cagri Coltekin, Furkan Akkurt, Bermet Chontaeva, Soudabeh Eslami, Sardana Ivanova, Gulnura Dzhumalieva, Aida Kasieva, Nikolett Mus, Jonathan Washington_
 |===
 
 === Sunday, March 29, 2026

--- a/content/en/workshop2026-program/index.adoc
+++ b/content/en/workshop2026-program/index.adoc
@@ -8,6 +8,8 @@ aliases: ["/workshop/program/"]
 contributors: []
 ---
 
+=== Sunday, March 29, 2026
+
 [cols="1,4"]
 |===
 | Time | Session
@@ -88,74 +90,3 @@ _Hüseyin Emir Akdağ_
 _Cagri Coltekin, Furkan Akkurt, Bermet Chontaeva, Soudabeh Eslami, Sardana Ivanova, Gulnura Dzhumalieva, Aida Kasieva, Nikolett Mus, Jonathan Washington_
 |===
 
-=== Sunday, March 29, 2026
-
-==== 09:00 - 09:15 Opening Remarks
-
-==== 09:15 - 10:30 Session 1
-
-SindBERT, the Sailor: Charting the Seas of Turkish NLP +
-*Raphael Schmitt, Stefan Schweter*
-
-Building a Turkish Large Language Model via Continual Pre-Training and Parameter-Efficient Adaptation +
-*Alperen Enes Bayar, Mert Ege, Gökhan Yurtalan, Alper Karamanlioglu, Berkan Demirel, Ramazan Gokberk Cinbis*
-
-When Semantic Overlap Is Not Enough: Cross-Lingual Euphemism Transfer Between Turkish and English +
-*Hasan Can Biyik, Libby Barak, Jing Peng, Anna Feldman*
-
-BIRDTurk: Adaptation of the BIRD Text-to-SQL Dataset to Turkish +
-*Burak Aktaş, Mehmet Can Baytekin, Süha Kağan Köse, Ömer İlbilgi, Elif Özge Yılmaz, Cagri Toraman, Bilge Kaan Görür*
-
-Overview of the SIGTURK 2026 Shared Task: Terminology-Aware Machine Translation for English–Turkish Scientific Texts +
-*Ali Gebeşçe, Abdulfattah Safa, Ege Uğur Amasya, Gözde Gül Şahin*
-
-==== 10:30 - 11:00 Coffee Break
-
-==== 11:00 - 12:00 Session 2
-
-TUNE: A Task For Turkish Machine Unlearning For Data Privacy +
-*Doruk Benli, Ada Canoğlu, Nehir İlkim Gönençer, Dilara Keküllüoğlu*
-
-TurkBench: A Benchmark for Evaluating Turkish Large Language Models +
-*Cagri Toraman, Ahmet Kaan Sever, Ayşe Aysu Cengiz, Elif Ecem Arslan, Görkem Sevinç, Sarp Kantar, Mete Mert Birdal, Yusuf Faruk Güldemir, Ali Buğra Kanburoğlu, Sezen Felekoğlu, Birsen Şahin Kütük, Büşra Tufan, Elif Genç, Serkan Coşkun, Gupse Ekin Demir, Muhammed Emin Arayıcı, Olgun Dursun, Onur Gungor, Susan Üsküdarlı, Abdullah Topraksoy, Esra Darıcı*
-
-Modelling the Morphology of Verbal Paradigms: A Case Study in the Tokenization of Turkish and Hebrew +
-*Giuseppe Samo, Paola Merlo*
-
-Beyond the Token: Correcting the Tokenization Bias in XAI via Morphologically-Aligned Projection +
-*Muhammet Anil Yagiz, Fahrettin Horasan*
-
-==== 14:00 - 17:00 Poster Session
-
-TR-EduVSum: A Turkish-Focused Dataset and Consensus Framework for Educational Video Summarization +
-*Figen Eğin, Aytuğ Onan*
-
-SarcasTürk: Turkish Context-Aware Sarcasm Detection Dataset +
-*Niyazi Ahmet Metin, Sevde Yılmaz, Osman Enes Erdoğdu, Elif Sude Meydan, Oğul Sümer, Dilara Keküllüoğlu*
-
-RAGTurk: Best Practices for Retrieval Augmented Generation in Turkish +
-*Süha Kağan Köse, Can Baytekin, Burak Aktaş, Kaan Görür, Evren Ayberk Munis, Deniz Yılmaz, Muhammed Yusuf Kartal, Cagri Toraman*
-
-A Morphology-Aware Evaluation of Turkish Syntax in Large Language Models +
-*Ezgi Başar, Arianna Bisazza*
-
-OCRTurk: A Comprehensive OCR Benchmark for Turkish +
-*Deniz Yılmaz, Evren Ayberk Munis, Cagri Toraman, Süha Kağan Köse, Burak Aktaş, Mehmet Can Baytekin, Bilge Kaan Görür*
-
-A Unified Turkic Idiom Understanding Benchmark: Idiom Detection and Semantic Retrieval Across Five Turkic Languages +
-*Gözde Aslantaş, Tunga Gungor*
-
-Language Matters: Target-Language Supervision for Political Bias Detection in Turkish News +
-*Umut Ozbagriacik, Haim Dubossarsky*
-
-Benchmarking Hate Speech Detection in Azerbaijani with Turkish Cross-Lingual Transfer and Transformer Models +
-*Tural Alizada, Haim Dubossarsky*
-
-From Lemmas to Dependencies: What Signals Drive Light Verbs Classification? +
-*Sercan Karakas, Yusuf Şimşek*
-
-Directed Attention is All You Need: Profiling Style from Limited Text Data +
-*Hüseyin Emir Akdağ*
-
-Tokenisation of Turkic Copula Constructions in Universal Dependencies +
-*Cagri Coltekin, Furkan Akkurt, Bermet Chontaeva, Soudabeh Eslami, Sardana Ivanova, Gulnura Dzhumalieva, Aida Kasieva, Nikolett Mus, Jonathan Washington*

--- a/content/en/workshop2026-program/index.adoc
+++ b/content/en/workshop2026-program/index.adoc
@@ -8,11 +8,11 @@ aliases: ["/workshop/program/"]
 contributors: []
 ---
 
-== Sunday, March 29, 2026
+=== Sunday, March 29, 2026
 
-=== 09:00 - 09:15 Opening Remarks
+==== 09:00 - 09:15 Opening Remarks
 
-=== 09:15 - 10:30 Session 1
+==== 09:15 - 10:30 Session 1
 
 SindBERT, the Sailor: Charting the Seas of Turkish NLP +
 *Raphael Schmitt, Stefan Schweter*
@@ -29,9 +29,9 @@ BIRDTurk: Adaptation of the BIRD Text-to-SQL Dataset to Turkish +
 Overview of the SIGTURK 2026 Shared Task: Terminology-Aware Machine Translation for English–Turkish Scientific Texts +
 *Ali Gebeşçe, Abdulfattah Safa, Ege Uğur Amasya, Gözde Gül Şahin*
 
-=== 10:30 - 11:00 Coffee Break
+==== 10:30 - 11:00 Coffee Break
 
-=== 11:00 - 12:00 Session 2
+==== 11:00 - 12:00 Session 2
 
 TUNE: A Task For Turkish Machine Unlearning For Data Privacy +
 *Doruk Benli, Ada Canoğlu, Nehir İlkim Gönençer, Dilara Keküllüoğlu*
@@ -45,7 +45,7 @@ Modelling the Morphology of Verbal Paradigms: A Case Study in the Tokenization o
 Beyond the Token: Correcting the Tokenization Bias in XAI via Morphologically-Aligned Projection +
 *Muhammet Anil Yagiz, Fahrettin Horasan*
 
-=== 14:00 - 17:00 Poster Session
+==== 14:00 - 17:00 Poster Session
 
 TR-EduVSum: A Turkish-Focused Dataset and Consensus Framework for Educational Video Summarization +
 *Figen Eğin, Aytuğ Onan*

--- a/content/en/workshop2026/index.adoc
+++ b/content/en/workshop2026/index.adoc
@@ -8,8 +8,6 @@ aliases: ["/workshop/"]
 contributors: []
 ---
 
-== Call for Papers
-
 SIGTURK— +
 The Second Workshop on +
 *Natural Language Processing for Turkic Languages* +
@@ -21,11 +19,34 @@ March 29, 2026
 
 === Program
 
-The workshop program can be found here: link:/workshop/program/[Workshop Program]
+[cols="1,3"]
+|===
+| Time | Session
+
+| 09:00 - 09:15
+| Opening Remarks
+
+| 09:15 - 10:30
+| Session 1
+
+| 10:30 - 11:00
+| Coffee Break
+
+| 11:00 - 12:00
+| Session 2
+
+| 14:00 - 17:00
+| Poster Session
+|===
+
+
+The full workshop program can be found here: link:/workshop/program/[Workshop Program]
 
 === Accepted papers
 
 The accepted papers can be found here: link:/workshop/accepted-papers/[Accepted Papers]
+
+== Call for Papers
 
 == Introduction
 

--- a/content/en/workshop2026/index.adoc
+++ b/content/en/workshop2026/index.adoc
@@ -19,6 +19,10 @@ Rabat, Morocco +
 March 29, 2026
 9 am - 12:30 pm
 
+=== Program
+
+The workshop program can be found here: link:/workshop/program/[Workshop Program]
+
 === Accepted papers
 
 The accepted papers can be found here: link:/workshop/accepted-papers/[Accepted Papers]


### PR DESCRIPTION
This PR adds the workshop program summary to the main workshop page and creates a detailed program page complete with paper titles and author names.
