### PR TITLE
Add proceedings links to home page

### DIFF
--- a/content/en/_index.adoc
+++ b/content/en/_index.adoc
@@ -22,7 +22,7 @@ We are excited to announce our second SIGTURK Workshop!
 Click on the poster below or see the link:/workshop2026[Call for Papers] and link:/sharedtask2026[Shared Task] pages for more informaiton.
 
 [link=/workshop2026]
-image::sigturk-workshop-poster.jpg[SIGTURK 2026 Workshop Poster]
+image::sigturk-workshop-poster.jpg[SIGTURK 2026 Workshop Poster,width=600]
 
 === Workshop 2024
 

--- a/content/en/_index.adoc
+++ b/content/en/_index.adoc
@@ -18,11 +18,12 @@ SIGTURK is the ACL Special Interest Group on Turkic Languages and aims to bring 
 
 *The workshop proceedings are available on the https://aclanthology.org/2026.sigturk-1.0[ACL Anthology].*
 
-The second SIGTURK workshop was co-located with EACL 2026 and took place on March 29, 2026 in Rabat, Morocco.
+The second SIGTURK workshop took place on March 29, 2026 in Rabat, Morocco and was co-located with https://2026.eacl.org/[EACL 2026].
+
 See the link:/workshop2026[Call for Papers] and link:/sharedtask2026[Shared Task] pages for more informaiton.
 
 === Workshop 2024
 
 *The workshop proceedings are available on the https://aclanthology.org/volumes/2024.sigturk-1/[ACL Anthology].*
 
-The first SIGTURK workshop was co-located with ACL 2024 and took place on August 15, 2024 in Bangkok, Thailand.
+The first SIGTURK workshop took place on August 15, 2024 in Bangkok, Thailand and was co-located with https://2024.aclweb.org/[ACL 2024].

--- a/content/en/_index.adoc
+++ b/content/en/_index.adoc
@@ -27,3 +27,5 @@ See the link:/workshop2026[Call for Papers] and link:/sharedtask2026[Shared Task
 *The workshop proceedings are available on the https://aclanthology.org/volumes/2024.sigturk-1/[ACL Anthology].*
 
 The first SIGTURK workshop took place on August 15, 2024 in Bangkok, Thailand and was co-located with https://2024.aclweb.org/[ACL 2024].
+
+See the link:/workshop2024[workshop page] for more informaiton.

--- a/content/en/_index.adoc
+++ b/content/en/_index.adoc
@@ -12,7 +12,11 @@ contributors: []
 
 SIGTURK is the ACL Special Interest Group on Turkic Languages and aims to bring together all researchers working on computational linguistics in Turkic languages.
 
-== Workshop 2026
+== Workshops
+
+=== Workshop 2026
+
+*The workshop proceedings are now available on the https://aclanthology.org/2026.sigturk-1.0[ACL Anthology].*
 
 We are excited to announce our second SIGTURK Workshop!
 Click on the poster below or see the link:/workshop2026[Call for Papers] and link:/sharedtask2026[Shared Task] pages for more informaiton.
@@ -20,4 +24,6 @@ Click on the poster below or see the link:/workshop2026[Call for Papers] and lin
 [link=/workshop2026]
 image::sigturk-workshop-poster.jpg[SIGTURK 2026 Workshop Poster]
 
+=== Workshop 2024
 
+The proceedings of our first workshop are available on the https://aclanthology.org/volumes/2024.sigturk-1/[ACL Anthology].

--- a/content/en/_index.adoc
+++ b/content/en/_index.adoc
@@ -18,11 +18,11 @@ SIGTURK is the ACL Special Interest Group on Turkic Languages and aims to bring 
 
 *The workshop proceedings are available on the https://aclanthology.org/2026.sigturk-1.0[ACL Anthology].*
 
-We are excited to announce our second SIGTURK Workshop!
+The second SIGTURK workshop was co-located with EACL 2026 and took place on March 29, 2026 in Rabat, Morocco.
 See the link:/workshop2026[Call for Papers] and link:/sharedtask2026[Shared Task] pages for more informaiton.
 
 === Workshop 2024
 
 *The workshop proceedings are available on the https://aclanthology.org/volumes/2024.sigturk-1/[ACL Anthology].*
 
-The first SIGTURK workshop as co-located with ACL 2024 and took place on August 15, 2024 in Bangkok, Thailand.
+The first SIGTURK workshop was co-located with ACL 2024 and took place on August 15, 2024 in Bangkok, Thailand.

--- a/content/en/_index.adoc
+++ b/content/en/_index.adoc
@@ -16,11 +16,13 @@ SIGTURK is the ACL Special Interest Group on Turkic Languages and aims to bring 
 
 === Workshop 2026
 
-*The workshop proceedings are now available on the https://aclanthology.org/2026.sigturk-1.0[ACL Anthology].*
+*The workshop proceedings are available on the https://aclanthology.org/2026.sigturk-1.0[ACL Anthology].*
 
 We are excited to announce our second SIGTURK Workshop!
 See the link:/workshop2026[Call for Papers] and link:/sharedtask2026[Shared Task] pages for more informaiton.
 
 === Workshop 2024
 
-The proceedings of our first workshop are available on the https://aclanthology.org/volumes/2024.sigturk-1/[ACL Anthology].
+*The workshop proceedings are available on the https://aclanthology.org/volumes/2024.sigturk-1/[ACL Anthology].*
+
+The first SIGTURK workshop as co-located with ACL 2024 and took place on August 15, 2024 in Bangkok, Thailand.

--- a/content/en/_index.adoc
+++ b/content/en/_index.adoc
@@ -19,10 +19,7 @@ SIGTURK is the ACL Special Interest Group on Turkic Languages and aims to bring 
 *The workshop proceedings are now available on the https://aclanthology.org/2026.sigturk-1.0[ACL Anthology].*
 
 We are excited to announce our second SIGTURK Workshop!
-Click on the poster below or see the link:/workshop2026[Call for Papers] and link:/sharedtask2026[Shared Task] pages for more informaiton.
-
-[link=/workshop2026]
-image::sigturk-workshop-poster.jpg[SIGTURK 2026 Workshop Poster,height=600]
+See the link:/workshop2026[Call for Papers] and link:/sharedtask2026[Shared Task] pages for more informaiton.
 
 === Workshop 2024
 

--- a/content/en/_index.adoc
+++ b/content/en/_index.adoc
@@ -22,7 +22,7 @@ We are excited to announce our second SIGTURK Workshop!
 Click on the poster below or see the link:/workshop2026[Call for Papers] and link:/sharedtask2026[Shared Task] pages for more informaiton.
 
 [link=/workshop2026]
-image::sigturk-workshop-poster.jpg[SIGTURK 2026 Workshop Poster,width=600]
+image::sigturk-workshop-poster.jpg[SIGTURK 2026 Workshop Poster,height=600]
 
 === Workshop 2024
 

--- a/content/en/workshop2026/index.adoc
+++ b/content/en/workshop2026/index.adoc
@@ -17,6 +17,10 @@ Rabat, Morocco +
 March 29, 2026
 9 am - 12:30 pm
 
+=== Proceedings
+
+The workshop proceedings are now available on the https://aclanthology.org/2026.sigturk-1.0[ACL Anthology].
+
 === Program
 
 [cols="1,3"]

--- a/content/en/workshop2026/index.adoc
+++ b/content/en/workshop2026/index.adoc
@@ -7,6 +7,8 @@ images: []
 aliases: ["/workshop/"]
 contributors: []
 ---
+:imagesoutdir: static
+:imagesdir: /assets/img
 
 SIGTURK— +
 The Second Workshop on +

--- a/content/en/workshop2026/index.adoc
+++ b/content/en/workshop2026/index.adoc
@@ -17,6 +17,8 @@ Rabat, Morocco +
 March 29, 2026
 9 am - 12:30 pm
 
+image::sigturk-workshop-poster.jpg[SIGTURK 2026 Workshop Poster,width=600]
+
 === Proceedings
 
 The workshop proceedings are now available on the https://aclanthology.org/2026.sigturk-1.0[ACL Anthology].


### PR DESCRIPTION
This PR adds links to workshop proceedings (hosted on the ACL Anthology) to the SIGTURK home page and both the 2024 and 2026 workshop pages.
